### PR TITLE
[resolved]  Unknown named module: "./obdInfo"

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,10 +15,13 @@
       "dom"
     ],
     "baseUrl": "./",
+    "paths": {
+      "obd-utils": ["src/index"]
+    },
     "typeRoots": [
       "node_modules/@types"
     ],
-    "strict": false,
+    "strict": false
   },
   "exclude": ["./lib", "./scripts", "./bin"]
 }


### PR DESCRIPTION
The tsconfig.json file does not currently include a paths configuration for module resolution. To resolve the module obd-utils correctly, you can add the paths configuration to the compilerOptions section.

Here is an updated version of your tsconfig.json file:


This will resolve the issue of Following

ERROR  Error: Unknown named module: "./obdInfo"

this happens when we use like
import { parseOBDResponse, getPIDInfo, getAllPIDs } from "obd-utils";

// Parse an OBD response
const parsedCommand = parseOBDResponse("41 05 3C");
